### PR TITLE
Three small fixes to ICE pipeline. 

### DIFF
--- a/pbtranscript-tofu/pbtranscript/pbtools/pbtranscript/Utils.py
+++ b/pbtranscript-tofu/pbtranscript/pbtools/pbtranscript/Utils.py
@@ -30,7 +30,7 @@ def revcmp(seq):
     NTMAP = {'a': 't', 'c': 'g', 't': 'a', 'g': 'c',
              'A': 'T', 'C': 'G', 'T': 'A', 'G': 'C',
              '*': '*', 'n': 'n', 'N': 'N'}
-    return "".join([NTMAP[x] for x in seq])[::-1]
+    return "".join([NTMAP[x] for x in seq.rstrip()])[::-1]
 
 
 def realpath(f):

--- a/pbtranscript-tofu/pbtranscript/pbtools/pbtranscript/io/FastaRandomReader.py
+++ b/pbtranscript-tofu/pbtranscript/pbtools/pbtranscript/io/FastaRandomReader.py
@@ -50,7 +50,7 @@ class FastaRandomReader:
                 break
             content += line.strip()
         # return SeqRecord(Seq(content), id=k)
-        return FastaRecord(name=k, sequence=content)
+        return FastaRecord(k, sequence=content)
 
     def __len__(self):
         return len(self.d)
@@ -148,7 +148,7 @@ class SubreadFastaReader(object):
                 if line.startswith('>'):
                     break
                 content += line.strip()
-            output.append(FastaRecord(name=seqid, sequence=content))
+            output.append(FastaRecord(seqid, sequence=content))
         return output
 
     def keys(self):


### PR DESCRIPTION
Hi,

Thanks for this cool project! Some fixes to the following errors that I encountered:

Fix 1: Nullbyte encountered in end of fasta sequence
```
pbtranscript.py classify {input.reads} {output.draft} --min_seq_len 300 --cpus 24 --flnc {output.flnc} --nfl {output.nfl} &> {log}
...
2015-12-05 21:28:11,980 [ERROR] Exiting pbtranscript with return code 1.
Traceback (most recent call last):
  File "/nfs/thumper.galaxyproject.org/home/ksahlin/local_python_modules/lib/python2.7/site-packages/pbtools.pbtranscript-2.2.3-py2.7-linux-x86_64.egg/EGG-INFO/scripts/pbtranscript.py", line 118, in run
    obj.run()
  File "/galaxy/home/ksahlin/local_python_modules/lib/python2.7/site-packages/pbtools.pbtranscript-2.2.3-py2.7-linux-x86_64.egg/pbtools/pbtranscript/Classifier.py", line 951, in run
    self.runChimeraDetector()
  File "/galaxy/home/ksahlin/local_python_modules/lib/python2.7/site-packages/pbtools.pbtranscript-2.2.3-py2.7-linux-x86_64.egg/pbtools/pbtranscript/Classifier.py", line 874, in runChimeraDetector
    job_name="fl")
  File "/galaxy/home/ksahlin/local_python_modules/lib/python2.7/site-packages/pbtools.pbtranscript-2.2.3-py2.7-linux-x86_64.egg/pbtools/pbtranscript/Classifier.py", line 831, in _detect_chimera
    extract_front_back_only=False)
  File "/galaxy/home/ksahlin/local_python_modules/lib/python2.7/site-packages/pbtools.pbtranscript-2.2.3-py2.7-linux-x86_64.egg/pbtools/pbtranscript/Classifier.py", line 341, in _chunkReads
    rcseq = revcmp(read.sequence)
  File "/galaxy/home/ksahlin/local_python_modules/lib/python2.7/site-packages/pbtools.pbtranscript-2.2.3-py2.7-linux-x86_64.egg/pbtools/pbtranscript/Utils.py", line 33, in revcmp
    return "".join([NTMAP[x] for x in seq])[::-1]
KeyError: '\x00'
```

Fix2: When no QV are provided to pbtranscript.py cluster (as it's an optional argument):

```
[ksahlin@brubeck scripts]$ pbtranscript.py cluster /galaxy/home/ksahlin/experiment_output/pacbio/transcriptomics/IsoSeqHumanMCF7-2013-subset/pbtranscript_classify/flnc.fa /galaxy/home/ksahlin/experiment_output/pacbio/transcriptomics/IsoSeqHumanMCF7-2013-subset/pbtranscript_cluster_no_QV/final.consensus.fa   --nfl_fa /galaxy/home/ksahlin/experiment_output/pacbio/transcriptomics/IsoSeqHumanMCF7-2013-subset/pbtranscript_classify/nfl.fa -d cluster --use_sge    --max_sge_jobs 40 --unique_id 300 --blasr_nproc 24
2015-12-06 19:25:37,093 [ERROR] Exiting pbtranscript with return code 1.
Traceback (most recent call last):
  File "/nfs/thumper.galaxyproject.org/home/ksahlin/local_python_modules/lib/python2.7/site-packages/pbtools.pbtranscript-2.2.3-py2.7-linux-x86_64.egg/EGG-INFO/scripts/pbtranscript.py", line 154, in run
    obj.run()
  File "/galaxy/home/ksahlin/local_python_modules/lib/python2.7/site-packages/pbtools.pbtranscript-2.2.3-py2.7-linux-x86_64.egg/pbtools/pbtranscript/Cluster.py", line 225, in run
    ice_fa2fq(firstSplit, self.ccs_fofn, firstSplit_fq)
  File "/galaxy/home/ksahlin/local_python_modules/lib/python2.7/site-packages/pbtools.pbtranscript-2.2.3-py2.7-linux-x86_64.egg/pbtools/pbtranscript/ice/IceUtils.py", line 898, in ice_fa2fq
    if ccs_fofn.endswith(".h5"):  # Input is a ccs.h5 file not a FOFN.
AttributeError: 'NoneType' object has no attribute 'endswith'
```

Fix 3:  name seems to be an unrecognized argument in FastaRecord:

```
[ksahlin@brubeck DALIGNER-d4aa4871122b35ac92e2cc13d9b1b1e9c5b5dc5c-ICEmod]$ pbtranscript.py cluster /galaxy/home/ksahlin/experiment_output/pacbio/transcriptomics/IsoSeqHumanMCF7-2013-subset/pbtranscript_classify/flnc.fa /galaxy/home/ksahlin/experiment_output/pacbio/transcriptomics/IsoSeqHumanMCF7-2013-subset/pbtranscript_cluster_no_QV/final.consensus.fa   --nfl_fa /galaxy/home/ksahlin/experiment_output/pacbio/transcriptomics/IsoSeqHumanMCF7-2013-subset/pbtranscript_classify/nfl.fa -d cluster
2015-12-06 21:39:27,996 [ERROR] Exiting pbtranscript with return code 1.
Traceback (most recent call last):
  File "/nfs/thumper.galaxyproject.org/home/ksahlin/local_python_modules/lib/python2.7/site-packages/pbtools.pbtranscript-2.2.3-py2.7-linux-x86_64.egg/EGG-INFO/scripts/pbtranscript.py", line 154, in run
    obj.run()
  File "/galaxy/home/ksahlin/local_python_modules/lib/python2.7/site-packages/pbtools.pbtranscript-2.2.3-py2.7-linux-x86_64.egg/pbtools/pbtranscript/Cluster.py", line 271, in run
    use_ccs_qv=self.ice_opts.use_finer_qv)
  File "/galaxy/home/ksahlin/local_python_modules/lib/python2.7/site-packages/pbtools.pbtranscript-2.2.3-py2.7-linux-x86_64.egg/pbtools/pbtranscript/ice/IceIterative.py", line 203, in __init__
    self.run_gcon_parallel(self.uc.keys())
  File "/galaxy/home/ksahlin/local_python_modules/lib/python2.7/site-packages/pbtools.pbtranscript-2.2.3-py2.7-linux-x86_64.egg/pbtools/pbtranscript/ice/IceIterative.py", line 497, in run_gcon_parallel
    self.run_gcon_parallel_helper(cids)
  File "/galaxy/home/ksahlin/local_python_modules/lib/python2.7/site-packages/pbtools.pbtranscript-2.2.3-py2.7-linux-x86_64.egg/pbtools/pbtranscript/ice/IceIterative.py", line 567, in run_gcon_parallel_helper
    in_fa_filename = self.write_in_fasta(cid)
  File "/galaxy/home/ksahlin/local_python_modules/lib/python2.7/site-packages/pbtools.pbtranscript-2.2.3-py2.7-linux-x86_64.egg/pbtools/pbtranscript/ice/IceIterative.py", line 789, in write_in_fasta
    self.seq_dict[seqid].sequence))
  File "/galaxy/home/ksahlin/local_python_modules/lib/python2.7/site-packages/pbtools.pbtranscript-2.2.3-py2.7-linux-x86_64.egg/pbtools/pbtranscript/io/FastaRandomReader.py", line 53, in __getitem__
    return FastaRecord(name=k, sequence=content)
TypeError: __init__() got an unexpected keyword argument 'name'
``` 

Best,
Kristoffer